### PR TITLE
Using data.gradOutput to hold the to-be-summed gradients

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -299,7 +299,10 @@ function gModule:accGradParameters(input,gradOutput,lr)
 		elseif not node.data.module and node.data.gradOutput then
 		elseif node.data.module then
 			local module = node.data.module
-			local gradOutput = getTotalGradOutput(node)
+			local gradOutput = node.data.gradOutput[1]
+			if #node.data.gradOutput > 1 then
+				gradOutput = node.data.gradOutputBuffer
+			end
 			local input = node.data.input
 			if #input == 1 then
 				input = input[1]


### PR DESCRIPTION
Problems with split() can be avoided by using the data.gradOutput consistently.
With the made changes, the node.data.gradOutput always holds the to-be-summed gradients.
