### PR TITLE
Checked that no split output is unused

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -32,7 +32,9 @@ end
 -- node in the order they are returned.
 function nnNode:split(noutput)
 	assert(noutput >= 2, "splitting to one output is not supported")
-	local mnode = self
+	local mnode = nngraph.Node({nSplitOutputs=noutput})
+	mnode:add(self,true)
+
 	local selectnodes = {}
 	for i=1,noutput do
 		local node = nngraph.Node({selectindex=i,input={}})


### PR DESCRIPTION
This pull request improves two things:
1) An error is raised, if an output of a split() is unused.
No output should be unused, to produce a meaningful gradInput.

2) It is allowed to call node:split() and use the node also
as an input somewhere else. The gradients from the two branches will be added together.
