### PR TITLE
Displayed the node ids of the input nodes in the mapindex

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -93,6 +93,10 @@ function gModule:__init(inputs,outputs)
 				forwardNode.data.nSplitOutputs))
 		end
 	end
+	-- Adding data.forwardNodeId for nicer node:label() output.
+	for i,forwardNode in ipairs(self.forwardnodes) do
+		forwardNode.data.forwardNodeId = forwardNode.id
+	end
 
 	self.output = nil
 	self.gradInput = nil

--- a/node.lua
+++ b/node.lua
@@ -62,32 +62,28 @@ function nnNode:label()
 			return tostring(data):gsub('\n','\\l')
 		end
 	end
-	local function getmapindexstr(data)
-		if not data then return '' end
-		if istable(data) then
-			local tstr = {}
-			for i,v in ipairs(data) do
-				local obj = v.module or v.input or v.data
-				local str = tostring(obj)
-				if obj.modules then
-					str = torch.typename(obj)
-				end
-				table.insert(tstr, str)
-			end
-			return '{' .. table.concat(tstr,',') .. '}'
-		else
-			return tostring(data):gsub('\n','\\l')
+	local function getmapindexstr(mapindex)
+		local tstr = {}
+		for i,data in ipairs(mapindex) do
+			local inputId = 'Node' .. (data.forwardNodeId or '')
+			table.insert(tstr, inputId)
 		end
+		return '{' .. table.concat(tstr,',') .. '}'
 	end
 
 	for k,v in pairs(self.data) do
 		local vstr = ''
 		if k=='mapindex' then
-			vstr = getmapindexstr(v)
+			if #v > 1 then 
+				vstr = getmapindexstr(v)
+				table.insert(lbl, k .. ' = ' .. vstr)
+			end
+		elseif k=='forwardNodeId' then
+			-- the forwardNodeId is not displayed in the label.
 		else
 			vstr = getstr(v)
+			table.insert(lbl, k .. ' = ' .. vstr)
 		end
-		table.insert(lbl, k .. ' = ' .. vstr)
 	end
 	return table.concat(lbl,"\\l")
 end


### PR DESCRIPTION
I changed the display of mapindex in the node:label().
1) The display will not fail if node.data has no module or input.
2) If a node has more than one input,
the ids of the input nodes will be displayed:
E.g., `mapindex = {Node6,Node11}`.

Tell me if you prefer something else.
