### PR TITLE
Added nn.ModuleFromCriterion to wrap a called Criterion.

### DIFF
--- a/ModuleFromCriterion.lua
+++ b/ModuleFromCriterion.lua
@@ -1,0 +1,35 @@
+
+--[[ A wrapper to turn a criterion into a module.
+
+The gradient with respect to the target will be zero.
+--]]
+local ModuleFromCriterion, parent = torch.class('nn.ModuleFromCriterion','nn.Module')
+function ModuleFromCriterion:__init(criterion)
+   self.criterion = criterion
+   self.output = torch.Tensor(1)
+   self.gradInput = {torch.Tensor(), torch.Tensor()}
+end
+
+--[[ The input is a {prediction, target} pair.
+The output is a tensor with one number: the criterion output.
+--]]
+function ModuleFromCriterion:updateOutput(input)
+   local prediction, target = unpack(input)
+   self.output[1] = self.criterion:updateOutput(prediction, target)
+   return self.output
+end
+
+function ModuleFromCriterion:updateGradInput(input, gradOutput)
+   local prediction, target = unpack(input)
+   local gradPrediction = self.criterion:updateGradInput(prediction, target)
+   self.gradInput[1]:resizeAs(gradPrediction):copy(gradPrediction):mul(gradOutput[1])
+   self.gradInput[2]:resizeAs(target):zero()
+   return self.gradInput
+end
+
+function ModuleFromCriterion:type(t)
+   self.criterion:type(t)
+   self.gradInput[1] = self.gradInput[1]:type(t)
+   self.gradInput[2] = self.gradInput[2]:type(t)
+   return parent.type(self,t)
+end

--- a/init.lua
+++ b/init.lua
@@ -7,6 +7,7 @@ nngraph = {}
 torch.include('nngraph','node.lua')
 torch.include('nngraph','gmodule.lua')
 torch.include('nngraph','graphinspecting.lua')
+torch.include('nngraph','ModuleFromCriterion.lua')
 
 -- handy functions
 local utils = paths.dofile('utils.lua')
@@ -41,4 +42,9 @@ function Module:__call__(...)
 	end
 
 	return mnode
+end
+
+local Criterion = torch.getmetatable('nn.Criterion')
+function Criterion:__call__(...)
+	return nn.ModuleFromCriterion(self)(...)
 end

--- a/test/test_ModuleFromCriterion.lua
+++ b/test/test_ModuleFromCriterion.lua
@@ -1,0 +1,57 @@
+
+require 'totem'
+require 'nngraph'
+local test = {}
+local tester = totem.Tester()
+
+function test.test_call()
+    local prediction = nn.Identity()()
+    local target = nn.Identity()()
+    local mse = nn.MSECriterion()({prediction, target})
+    local costBits = nn.MulConstant(1/math.log(2))(mse)
+    local net = nn.gModule({prediction, target}, {costBits})
+
+    local input = {torch.randn(3, 5), torch.rand(3, 5)}
+    local criterion = nn.MSECriterion()
+    local output = net:forward(input)
+    criterion:forward(input[1], input[2])
+    tester:eq(output[1], criterion.output/math.log(2), "output", 1e-14)
+
+    local gradOutput = torch.randn(1)
+    local gradInput = net:backward(input, gradOutput)
+    criterion:backward(input[1], input[2])
+    tester:eq(gradInput[1], criterion.gradInput:clone():mul(gradOutput[1]/math.log(2)), "gradPrediction", 1e-14)
+    tester:eq(gradInput[2], torch.zeros(input[2]:size()), "gradTarget")
+end
+
+function test.test_grad()
+    local prediction = nn.Identity()()
+    local zero = nn.MulConstant(0)(prediction)
+    -- The target is created inside of the nngraph
+    -- to ignore the zero gradTarget.
+    local target = nn.AddConstant(1.23)(zero)
+    local mse = nn.MSECriterion()({prediction, target})
+    local net = nn.gModule({prediction}, {mse})
+
+    local input = torch.randn(4, 7)
+    totem.nn.checkGradients(tester, net, input)
+end
+
+local function module()
+    local module = nn.ModuleFromCriterion(nn.MSECriterion())
+    local input = {torch.randn(3, 5), torch.randn(3, 5)}
+    return module, input
+end
+
+function test.test_serializable()
+    local module, input = module()
+    totem.nn.checkSerializable(tester, module, input)
+end
+
+function test.test_typeCastable()
+    local module, input = module()
+    totem.nn.checkTypeCastable(tester, module, input)
+end
+
+
+tester:add(test):run()


### PR DESCRIPTION
@wojciechz @koraykv
I took an inspiration from Wojciech.
And I provided the support for Criterions inside of a nngraph.
A Criterion is automatically wrapped by a module,
when converting the criterion to a node.

Is this support matching your needs?
