### PR TITLE
Fixing gModule behaviour for module:training() and module:evaluate() methods

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -113,6 +113,14 @@ function gModule:apply(func)
 	end
 end
 
+function gModule:training()
+	self:apply(function(module) module:training() end)
+end
+
+function gModule:evaluate()
+	self:apply(function(module) module:evaluate() end)
+end
+
 function gModule:type(type)
 	self:apply(function(module) module:type(type) end)
 	return self


### PR DESCRIPTION
This makes gModules behave consistently with nn.Modules and nn.Container, and solves the issues of trying to change the behaviour of layers like nn.Dropout which may be in nested gModules.