### PR TITLE
Fixing problem with debug labels for nodes

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -21,8 +21,10 @@ end
 --[[ Build a string label which will be used a tooltip when
   making a graph.]]
 function nnNode:_makeDebugLabel(dinfo)
-  self.data.annotations._debugLabel = string.format('[%s]:%d',
-      dinfo.short_src, dinfo.currentline, dinfo.name)
+	if dinfo then
+		self.data.annotations._debugLabel = string.format('[%s]:%d',
+			dinfo.short_src, dinfo.currentline, dinfo.name)
+	end
 end
 
 
@@ -46,12 +48,13 @@ end
 -- node in the order they are returned.
 function nnNode:split(noutput)
 	assert(noutput >= 2, "splitting to one output is not supported")
-	local mnode = nngraph.Node({nSplitOutputs=noutput})
+	local debugLabel = self.data.annotations._debugLabel
+	local mnode = nngraph.Node({nSplitOutputs=noutput, annotations={_debugLabel=debugLabel .. '-mnode'}})
 	mnode:add(self,true)
 
 	local selectnodes = {}
 	for i=1,noutput do
-		local node = nngraph.Node({selectindex=i,input={}})
+		local node = nngraph.Node({selectindex=i,input={}, annotations={_debugLabel=debugLabel .. '-' .. i}})
 		node:add(mnode,true)
 		table.insert(selectnodes,node)
 	end

--- a/test/test_nngraph.lua
+++ b/test/test_nngraph.lua
@@ -80,6 +80,14 @@ function test.test_twoInputs2()
     checkGradients(module, input)
 end
 
+function test.test_splitDebugLabels()
+    local node = nn.Identity()()
+    node.data.annotations._debugLabel = "node"
+    local node1, node2 = node:split(2)
+    assert(node1.data.annotations._debugLabel == "node-1")
+    assert(node2.data.annotations._debugLabel == "node-2")
+end
+
 function test.test_identity()
     local in1 = nn.Identity()()
     local in2 = nn.Identity()()


### PR DESCRIPTION
The following code does not work from the command line interpreter:
    x=nn.Identity()()
    y=nn.Identity()()
    z=nn.Identity()()
    a,b,c = nn.Identity()({x,y,z}):split(3)
 