### PR TITLE
Added share function for gModule

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -363,6 +363,15 @@ function gModule:parameters()
 	return p,gp
 end
 
+-- Added share function
+function gModule:share(gModuleToShare, ...)
+   for indexNode, node in ipairs(self.forwardnodes) do
+      if node.data.module then
+	 node.data.module:share(gModuleToShare.forwardnodes[indexNode].data.module, ...)
+      end
+   end
+end
+
 function gModule:__tostring__()
 	return self.name or torch.type(self)
 end


### PR DESCRIPTION
Added a share function for gModule so that parameter sharing is easier for nngraph modules. Please let me know if there is any caveat for this. I am using this a lot for my recurrent net implementations and it made parameter sharing between recurrent cells in a much easier and consistent way.

This code is copied form Google group, by Benjamin Marechal, ref:
https://groups.google.com/forum/#!msg/torch7/4f_wMQ6G2io/mAO43uoYIAYJ
