### PR TITLE
Integrate apply() and type() improvements from https://github.com/torch/nn/pull/303

### DIFF
--- a/ModuleFromCriterion.lua
+++ b/ModuleFromCriterion.lua
@@ -26,10 +26,3 @@ function ModuleFromCriterion:updateGradInput(input, gradOutput)
    self.gradInput[2]:resizeAs(target):zero()
    return self.gradInput
 end
-
-function ModuleFromCriterion:type(t)
-   self.criterion:type(t)
-   self.gradInput[1] = self.gradInput[1]:type(t)
-   self.gradInput[2] = self.gradInput[2]:type(t)
-   return parent.type(self,t)
-end


### PR DESCRIPTION
* `nn.Module` now has an `:apply()` method, so use that instead of gmodule's custom `apply()`.
* `nn.Module:type()` now preserves sharing semantics, but I have to pass a `tensorCache` argument through for gmodule to support it.
* Add missing method `updateParameters`

I also added `self.modules` to gmodule, which should make some things easier. It would be great if gmodule could inherit from nn.Container instead of nn.Module, as a lot of the functionality here is duplicated from nn.Container.

Note: this PR depends on https://github.com/torch/nn/pull/303.