### PR TITLE
Added an assert to check the number of inputs to a split.

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -252,6 +252,11 @@ function gModule:runForwardFunction(func,input)
 			else
 				output = func(node.data.module,input)
 			end
+			if node.data.nSplitOutputs and node.data.nSplitOutputs ~= #output then
+					error(string.format("split(%s) cannot split %s outputs",
+						node.data.nSplitOutputs,
+						#output))
+			end
 			-- propagate the output to children
 			propagate(node,output)
 		end

--- a/test/test_nngraph.lua
+++ b/test/test_nngraph.lua
@@ -358,5 +358,26 @@ function test.test_annotateGraph()
   checkDotFile(bg_tmpfile)
 end
 
+function test.test_splitMore()
+  local nSplits = 2
+  local in1 = nn.Identity()()
+  local out1, out2 = nn.SplitTable(2)(in1):split(nSplits)
+
+  local model = nn.gModule({in1}, {out1, out2})
+  local input = torch.randn(10, nSplits + 1)
+  local ok, result = pcall(model.forward, model, input)
+  assert(not ok, "the extra input to split should be detected")
+end
+
+function test.test_splitLess()
+  local nSplits = 3
+  local in1 = nn.Identity()()
+  local out1, out2, out3 = nn.SplitTable(2)(in1):split(nSplits)
+
+  local model = nn.gModule({in1}, {out1, out2, out3})
+  local input = torch.randn(10, nSplits - 1)
+  local ok, result = pcall(model.forward, model, input)
+  assert(not ok, "the missing input to split should be detected")
+end
 
 tester:add(test):run()


### PR DESCRIPTION
When running a graph, the splitting will check the number of elements in the table
passed to a :split(N).
Previously any mistake was quietly ignored.