### PR TITLE
Replace utils.istensor with torch.isTensor.

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -1,7 +1,7 @@
 
 local nesting = paths.dofile('nesting.lua')
 local utils = paths.dofile('utils.lua')
-local istensor = utils.istensor
+local istensor = torch.isTensor
 local istable = utils.istable
 local istorchclass = utils.istorchclass
 

--- a/init.lua
+++ b/init.lua
@@ -10,7 +10,7 @@ torch.include('nngraph','ModuleFromCriterion.lua')
 
 -- handy functions
 local utils = paths.dofile('utils.lua')
-local istensor = utils.istensor
+local istensor = torch.isTensor
 local istable = utils.istable
 local istorchclass = utils.istorchclass
 

--- a/nesting.lua
+++ b/nesting.lua
@@ -2,7 +2,7 @@
 local nesting = {}
 
 local utils = paths.dofile('utils.lua')
-local istensor = utils.istensor
+local istensor = torch.isTensor
 
 -- Creates a clone of a tensor or of a table with tensors.
 function nesting.cloneNested(obj)

--- a/node.lua
+++ b/node.lua
@@ -1,6 +1,6 @@
 
 local utils = paths.dofile('utils.lua')
-local istensor = utils.istensor
+local istensor = torch.isTensor
 local istable = utils.istable
 local istorchclass = utils.istorchclass
 require 'debug'

--- a/utils.lua
+++ b/utils.lua
@@ -1,12 +1,5 @@
 local utils = {}
 
-function utils.istensor(x)
-   if torch.typename(x) and torch.typename(x):find('Tensor') then
-      return true
-   end
-   return false
-end
-
 function utils.istorchclass(x)
    return type(x) == 'table' and torch.typename(x)
 end


### PR DESCRIPTION
torch.isTensor is more precise: utils.istensor returns true for, say, a module with Tensor in its name, but torch.isTensor does not.