### PR TITLE
Adding a :applyToModules() method to gModule, and :training() and :evaluate() should be applied 'self' as well.

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -177,14 +177,22 @@ function gModule:share(gm, ...)
 end
 
 function gModule:training()
+   parent.training(self)
    for _, m in ipairs(self.modules) do
       m:training()
    end
 end
 
 function gModule:evaluate()
+   parent.evaluate(self)
    for _, m in ipairs(self.modules) do
       m:evaluate()
+   end
+end
+
+function gModule:applyToModules(func)
+   for _, m in ipairs(self.modules) do
+      func(m)
    end
 end
 


### PR DESCRIPTION
I understand that nngraph is undergoing some changes, but in the mean time some small improvements that are forwards-compatible with these upcoming changes:

1. `gModule:applyToModules()` replaces the original functionality of `gModule:apply()`. I have added the same method to `nn.Container`, so that when `gModule` becomes a subclass of `nn.Container`, the new method becomes redundant.

2. `gModule:training()` and `gModule:evaluate()` should call `nn.Module:training()` and `nn.Module:evaluate()`, similarly to `nn.Container`. 
