### PR TITLE
Safer copynested

### DIFF
--- a/nesting.lua
+++ b/nesting.lua
@@ -59,10 +59,10 @@ function nesting.copyNested(output, input)
       for key, child in pairs(input) do
           nesting.copyNested(output[key], child)
       end
-      -- Extra elements are removed from the output.
+      -- Extra elements in the output table cause an error.
       for key, child in pairs(output) do
          if not input[key] then
-            output[key] = nil
+            error('key ' .. key .. ' present in output but not in input')
          end
       end
    end

--- a/nesting.lua
+++ b/nesting.lua
@@ -62,7 +62,8 @@ function nesting.copyNested(output, input)
       -- Extra elements in the output table cause an error.
       for key, child in pairs(output) do
          if not input[key] then
-            error('key ' .. key .. ' present in output but not in input')
+            error('key ' .. tostring(key) ..
+                  ' present in output but not in input')
          end
       end
    end


### PR DESCRIPTION
As recommended by @fidlej , cause an error when there are extra keys in the output table for copyNested.