### PR TITLE
Improved error message (expecting table of inputs)

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -274,7 +274,7 @@ function gModule:runForwardFunction(func,input)
    if nInputs <= 1 then
       input={input}
    elseif type(input) ~= "table" then
-      error(string.format("expecting %s inputs", nInputs))
+      error(string.format("expecting table of %s inputs", nInputs))
    end
    local function neteval(node)
       local function propagate(node,x)


### PR DESCRIPTION
I think a better error message. Currently if I pass in 2 comma separated inputs the error is: "Error, expecting 2 inputs". After this change it will be "Error, expecting table of 2 inputs.".