### PR TITLE
Fix to make compatible with MarginRankingCriterion

### DIFF
--- a/ModuleFromCriterion.lua
+++ b/ModuleFromCriterion.lua
@@ -26,11 +26,13 @@ function ModuleFromCriterion:updateGradInput(input, gradOutput)
    local gradPrediction = self.criterion:updateGradInput(prediction, target)
    if type(gradPrediction) == 'table' then
       if type(self.gradInput[1]) ~= 'table' then
-        self.gradInput[1] = gradPrediction
-      else
-        for i=1, #gradPrediction do
-            self.gradInput[1][i]:resizeAs(gradPrediction[i]):copy(gradPrediction[i]):mul(gradOutput[1])
-        end
+         self.gradInput[1] = {} -- initializing to table first time if it is tensor (which it is: line 10)
+         for i=1, #gradPrediction do
+            self.gradInput[1][i] = gradPrediction[i]:clone() -- and putting tensors of right size inside.
+         end
+      end
+      for i=1, #gradPrediction do
+         self.gradInput[1][i]:resizeAs(gradPrediction[i]):copy(gradPrediction[i]):mul(gradOutput[1])
       end
    else
       self.gradInput[1]:resizeAs(gradPrediction):copy(gradPrediction):mul(gradOutput[1])

--- a/ModuleFromCriterion.lua
+++ b/ModuleFromCriterion.lua
@@ -28,7 +28,7 @@ function ModuleFromCriterion:updateGradInput(input, gradOutput)
       if type(self.gradInput[1]) ~= 'table' then
          self.gradInput[1] = {} -- initializing to table first time if it is tensor (which it is: line 10)
          for i=1, #gradPrediction do
-            self.gradInput[1][i] = gradPrediction[i]:clone() -- and putting tensors of right size inside.
+            self.gradInput[1][i] = gradPrediction[i].new() -- and putting tensors of right size inside.
          end
       end
       for i=1, #gradPrediction do

--- a/ModuleFromCriterion.lua
+++ b/ModuleFromCriterion.lua
@@ -24,7 +24,17 @@ end
 function ModuleFromCriterion:updateGradInput(input, gradOutput)
    local prediction, target = unpack(input)
    local gradPrediction = self.criterion:updateGradInput(prediction, target)
-   self.gradInput[1]:resizeAs(gradPrediction):copy(gradPrediction):mul(gradOutput[1])
+   if type(gradPrediction) == 'table' then
+      if type(self.gradInput[1]) ~= 'table' then
+        self.gradInput[1] = gradPrediction
+      else
+        for i=1, #gradPrediction do
+            self.gradInput[1][i]:resizeAs(gradPrediction[i]):copy(gradPrediction[i]):mul(gradOutput[1])
+        end
+      end
+   else
+      self.gradInput[1]:resizeAs(gradPrediction):copy(gradPrediction):mul(gradOutput[1])
+   end
    self.gradInput[2]:resizeAs(target):zero()
    return self.gradInput
 end


### PR DESCRIPTION
Before the fix ModuleFromCriterion assumes that gradPrediction (line 26) is a tensor. This assumption breaks for criterions like MarginRankingCriterion where it is a table instead. Adding code to make it compatible for criterions where prediction (as well as gradPrediction) can be a table.