### PR TITLE
Return type of gModule when no arguments are passed to method: type().

### DIFF
--- a/gmodule.lua
+++ b/gmodule.lua
@@ -220,6 +220,10 @@ local function recursiveType(param, type_str)
 end
 
 function gModule:type(type, tensorCache)
+   if not type then
+      return self._type
+   end
+
    tensorCache = tensorCache or {}
 
    local function applyTypeToTable(table)
@@ -244,6 +248,7 @@ function gModule:type(type, tensorCache)
       end
    end
 
+   self._type = type
    return self
 end
 


### PR DESCRIPTION
As per torch/nn#691, the `nn.Module` interface can be queried for the module's type by calling the `type()` method with no arguments. This change makes `nn.gModule` conform to this API as well.

After initialization, this returns the default type of `torch.Tensor` (as `self._type` is initialized in `nn.Module.__init`). If the module's type is explicitly changed using `type(<some_type>)`, then this is remembered and returned the next time `type()` is called without arguments.