### PR TITLE
overload operator __unm and __sub to support module chaining

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -58,4 +58,23 @@ function Criterion:__call__(...)
    return nn.ModuleFromCriterion(self)(...)
 end
 
+
+
+
+Module.__unm__ = function( obj )
+    return obj()
+end
+
+Module.__sub__ = function( prev, next )
+    return next(prev)
+end
+
+
+do
+    local Node = torch.getmetatable('nngraph.Node')
+    Node.__sub__ = function( prev, next )
+        return next(prev)
+    end
+end
+
 return nngraph


### PR DESCRIPTION
By overloading `__unm__` and `__sub__` of `nn.Module` and `__sub__` of `nngraph.Node`, graph construction is easier and human readable.

For example,
```lua
h1 = nn.Linear(20, 10)()
h2 = nn.Linear(10, 1)(nn.Tanh()(nn.Linear(10, 10)(nn.Tanh()(h1))))
mlp = nn.gModule({h1}, {h2})
```
can be written as
```lua
h1 = - nn.Linear(20,10)
h2 = h1
     - nn.Tanh()
     - nn.Linear(10,10)
     - nn.Tanh()
     - nn.Linear(10, 1)
mlp = nn.gModule({h1}, {h2})
```

In the original syntax, as the graph getting bigger and more complicated, the increasing amount of nested parentheses may be confusing too. In this case, module chaining is clearer and easier to debug since we can see the data flow at a glance.

For example
```lua
input = nn.Identity()()
L1 = nn.Tanh()(nn.Linear(10, 20)(input))
L2 = nn.Tanh()(nn.Linear(30, 60)(nn.JoinTable(1)({input, L1})))
L3 = nn.Tanh()(nn.Linear(80, 160)(nn.JoinTable(1)({L1, L2})))
g = nn.gModule({input},{L3})
```
can be written as
```lua
input = - nn.Identity()
L1 =  input 
     - nn.Linear(10, 20) 
     - nn.Tanh()
L2 =  { input, L1 }
     -  nn.JoinTable(1)
     -  nn.Linear(30,60) 
     -  nn.Tanh()
L3 = { L1,L2 }
     - nn.JoinTable(1)
     - nn.Linear(80,160)
     - nn.Tanh()
g = nn.gModule({input},{L3})
```
