### PR TITLE
avoid nnNode:label() error for string data

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -137,7 +137,8 @@ function nnNode:label()
       elseif istable(data) then
          local tstr = {}
          for i,v in ipairs(data) do
-            table.insert(tstr, getstr(v))
+            local gsv = getstr(v) -- avoids luajit error for type(v)='string'
+            table.insert(tstr, gsv)
          end
          return '{' .. table.concat(tstr,',') .. '}'
       else

--- a/test/test_nngraph.lua
+++ b/test/test_nngraph.lua
@@ -371,6 +371,24 @@ function test.test_gradInputType()
       checkDotFile(bg_tmpfile)
    end
 
+   function test.test_table_string_label()
+      local inp = nn.Identity()()
+      local in1 = nn.SelectTable(1)(inp)
+      local in2 = nn.SelectTable(2)(inp)
+      local out = nn.Linear(10,10)(in1)
+      -- in2 propagates 'as is':   it could be, say, a string debug tag
+      local mod = nn.gModule({inp}, {out,in2})
+
+      local mod_out = mod:forward{
+         torch.Tensor(10),
+         "nnNode:label() should handle a string without bad argument #2 to 'insert' (number expected, got string) error"
+      }
+      --print('mod_out[1] type is '..torch.type(mod_out[1]))
+      --print('mod_out[2] type is '..torch.type(mod_out[2])) -- string
+      local dot0 = mod.fg:todot()
+      --print(dot0)
+   end
+
    function test.test_splitMore()
       local nSplits = 2
       local in1 = nn.Identity()()


### PR DESCRIPTION
Simple 1-line "robustness" PR (and associated test)

Original nngraph with luajit was giving me the following error for labelling a table containing a string value:
```
kruus@snake10$ th test_stringlabel.lua
mod_out[1] type is torch.DoubleTensor	
mod_out[2] type is string	
/local/kruus/torch/install/bin/luajit: /local/kruus/torch/install/share/lua/5.1/nngraph/node.lua:143:
----------> bad argument #2 to 'insert' (number expected, got string)
stack traceback:
	[C]: in function 'insert'
	/local/kruus/torch/install/share/lua/5.1/nngraph/node.lua:143: in function 'getstr'
	/local/kruus/torch/install/share/lua/5.1/nngraph/node.lua:169: in function 'label'
	/local/kruus/torch/install/share/lua/5.1/graph/init.lua:242: in function 'todot'
	test_stringlabel.lua:18: in function 'test_table_string'
       etc.
```
This error can happen with the following test program, and something similar has been added to tests/test_nngraph.lua
```
require 'nngraph'
function test_table_string()
  local inp = nn.Identity()()
  local in1 = nn.SelectTable(1)(inp)
  local in2 = nn.SelectTable(2)(inp)
  local out = nn.Linear(10,10)(in1)
  -- in2 propagates 'as is':   it could be, say, a string debug tag
  local mod = nn.gModule({inp}, {out,in2})

  local inp_tensor = torch.Tensor(10)
  local inp_string = 'Hello'
  local mod_out = mod:forward{
    torch.Tensor(10),
    "nnNode:label() should handle a string without bad argument #2 to 'insert' (number expected, got string) error"
  }
  print('mod_out[1] type is '..torch.type(mod_out[1]))
  print('mod_out[2] type is '..torch.type(mod_out[2])) -- string
  local dot0 = mod.fg:todot()
  --print(dot0)
end

test_table_string()
```

Luajit runs this fine if the getstr('some string') first goes into a local variable, and then into ``table.insert``. 

**Dunno' why**.